### PR TITLE
Add offline RAG assistant skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+venv/
+.env
+indexes/
+data/
+*.faiss
+*.bin
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Offline Medical RAG Assistant
+
+This project provides a lightweight offline chat assistant for medical research. It uses open-source models and datasets to run entirely on a MacBook M1 with 16 GB RAM.
+
+**Disclaimer:** This software is for research purposes only and does **not** constitute medical advice.
+
+## Setup
+1. Install [Homebrew](https://brew.sh/) if missing.
+2. Install Python 3.12 via Homebrew:
+   ```bash
+   brew install python@3.12
+   ```
+3. Create a virtual environment and install dependencies:
+   ```bash
+   python3.12 -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+4. Download sentence-transformer and LLM weights manually (see `data_sources.json`).
+5. Place downloaded models under `models/` and datasets under `data/`.
+
+## Building the Index
+Run the indexer after datasets are prepared:
+```bash
+python src/indexer.py
+```
+This generates `indexes/pmc.faiss` used for retrieval.
+
+## Running the Chat UI
+Start the Gradio interface:
+```bash
+python src/gui.py
+```
+Open the local address printed in the terminal. Chat responses will cite retrieved text passages.
+
+## Tests
+Run the basic pipeline test:
+```bash
+pytest
+```
+
+## Data Sources
+Dataset download links are placeholders in `src/data_sources.json`. Fill them in and execute:
+```bash
+python src/data_ingestion.py
+```
+This may take a long time and requires substantial disk space.
+
+

--- a/project_structure.txt
+++ b/project_structure.txt
@@ -1,0 +1,16 @@
+.
+├── .gitignore
+├── requirements.txt
+├── project_structure.txt
+├── README.md
+├── src/
+│   ├── config.py
+│   ├── embeddings.py
+│   ├── indexer.py
+│   ├── data_sources.json
+│   ├── data_ingestion.py
+│   ├── rag_chat.py
+│   └── gui.py
+└── tests/
+    └── test_pipeline.py
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+faiss-cpu==1.8.0
+sentence-transformers==2.6.1
+ctransformers==0.2.27
+gradio==4.21.0
+pydantic==2.7.1
+tqdm==4.66.4
+lxml==5.1.0
+beautifulsoup4==4.12.3
+pytest==8.2.1
+requests==2.32.2
+

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,25 @@
+"""Configuration for paths and model settings.
+
+Usage example:
+    from config import settings
+    print(settings.data_dir)
+"""
+from pathlib import Path
+from pydantic import BaseModel
+
+
+class Settings(BaseModel):
+    data_dir: Path = Path("data")
+    index_dir: Path = Path("indexes")
+    model_dir: Path = Path("models")
+    embed_model: str = "sentence-transformers/all-MiniLM-L6-v2"
+    llm_model: str = "mistral-7b-instruct.Q4_0.gguf"
+    top_k: int = 5
+    chunk_size: int = 400
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+settings = Settings()
+

--- a/src/data_ingestion.py
+++ b/src/data_ingestion.py
@@ -1,0 +1,58 @@
+"""Download and extract datasets.
+
+Usage example:
+    python src/data_ingestion.py
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Dict
+
+import requests
+from tqdm import tqdm
+
+from .config import settings
+
+
+def read_sources() -> Dict[str, str]:
+    with open(Path(__file__).with_name("data_sources.json")) as fh:
+        return json.load(fh)
+
+
+def download(url: str, dest: Path) -> Path:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        return dest
+    if "TODO" in url:
+        raise ValueError(f"Download URL not provided for {dest.name}")
+
+    with requests.get(url, stream=True) as r:
+        r.raise_for_status()
+        with open(dest, "wb") as fh:
+            for chunk in tqdm(r.iter_content(chunk_size=8192), desc=f"Downloading {dest.name}"):
+                if chunk:
+                    fh.write(chunk)
+    return dest
+
+
+def extract_archive(archive: Path, out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shutil.unpack_archive(str(archive), str(out_dir))
+
+
+def main() -> None:
+    sources = read_sources()
+    for name, url in sources.items():
+        try:
+            archive = download(url, settings.data_dir / f"{name}.zip")
+            extract_archive(archive, settings.data_dir / name)
+        except Exception as exc:  # pylint: disable=broad-except
+            print(f"Failed {name}: {exc}")
+            print("TODO: provide valid URL in data_sources.json")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/data_sources.json
+++ b/src/data_sources.json
@@ -1,0 +1,6 @@
+{
+  "pubmed_central": "TODO_EXTERNAL_LINK_PMC",
+  "drugbank": "TODO_EXTERNAL_LINK_DRUGBANK",
+  "clinical_trials": "TODO_EXTERNAL_LINK_CT"
+}
+

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -1,0 +1,23 @@
+"""Sentence-Transformers embedding wrapper.
+
+Usage example:
+    from embeddings import Embedder
+    vec = Embedder().encode("hello")
+"""
+from typing import Optional
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+from .config import settings
+
+
+class Embedder:
+    """Lightweight embedding helper."""
+
+    def __init__(self, model_name: Optional[str] = None) -> None:
+        self.model = SentenceTransformer(model_name or settings.embed_model)
+
+    def encode(self, text: str) -> np.ndarray:
+        vector = self.model.encode(text, normalize_embeddings=True)
+        return np.array(vector, dtype="float32")
+

--- a/src/gui.py
+++ b/src/gui.py
@@ -1,0 +1,25 @@
+"""Gradio chat interface.
+
+Usage example:
+    python src/gui.py
+"""
+import asyncio
+import gradio as gr
+
+from .rag_chat import answer
+
+
+def chat(query: str, history: list[tuple[str, str]]) -> str:
+    return asyncio.run(answer(query))
+
+
+def main() -> None:
+    with gr.Blocks() as demo:
+        gr.Markdown("# Offline Medical Assistant\n*Not medical advice*")
+        gr.ChatInterface(fn=chat)
+    demo.launch()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/indexer.py
+++ b/src/indexer.py
@@ -1,0 +1,55 @@
+"""Builds and saves the FAISS index.
+
+Usage example:
+    python src/indexer.py
+"""
+from pathlib import Path
+import pickle
+from typing import Iterable
+
+import faiss
+import numpy as np
+from tqdm import tqdm
+
+from .config import settings
+from .embeddings import Embedder
+
+
+def load_documents() -> list[str]:
+    """Load text documents from the data directory."""
+    docs = []
+    for path in Path(settings.data_dir).rglob("*.txt"):
+        docs.append(path.read_text())
+    return docs
+
+
+def build_index(docs: Iterable[str]) -> tuple[faiss.IndexFlatIP, list[str]]:
+    embedder = Embedder()
+    vectors = [embedder.encode(doc) for doc in tqdm(docs, desc="Embedding")]
+    dim = vectors[0].shape[0]
+    index = faiss.IndexFlatIP(dim)
+    index.add(np.stack(vectors))
+    return index, list(docs)
+
+
+def save_index(index: faiss.IndexFlatIP, docs: list[str]) -> None:
+    settings.index_dir.mkdir(parents=True, exist_ok=True)
+    index_path = settings.index_dir / "pmc.faiss"
+    faiss.write_index(index, str(index_path))
+    with open(settings.index_dir / "pmc.pkl", "wb") as fh:
+        pickle.dump(docs, fh)
+
+
+def main() -> None:
+    docs = load_documents()
+    if not docs:
+        print("No documents found in", settings.data_dir)
+        return
+    index, store = build_index(docs)
+    save_index(index, store)
+    print("Index built with", len(store), "documents")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/rag_chat.py
+++ b/src/rag_chat.py
@@ -1,0 +1,68 @@
+"""RAG pipeline functions.
+
+Usage example:
+    from rag_chat import answer
+    response = asyncio.run(answer("What is aspirin?"))
+"""
+from __future__ import annotations
+
+import asyncio
+import pickle
+from pathlib import Path
+from typing import List
+
+import faiss
+import numpy as np
+from ctransformers import AutoModelForCausalLM
+
+from .config import settings
+from .embeddings import Embedder
+
+
+class RAGChat:
+    def __init__(self) -> None:
+        self.embedder = Embedder()
+        index_path = settings.index_dir / "pmc.faiss"
+        store_path = settings.index_dir / "pmc.pkl"
+        if not index_path.exists() or not store_path.exists():
+            raise FileNotFoundError("Index files not found. Run indexer first.")
+        self.index = faiss.read_index(str(index_path))
+        with open(store_path, "rb") as fh:
+            self.docs = pickle.load(fh)
+        model_path = settings.model_dir / settings.llm_model
+        if not model_path.exists():
+            raise FileNotFoundError(f"LLM weights missing: {model_path}")
+        self.llm = AutoModelForCausalLM.from_pretrained(
+            model_path,
+            model_type="llama",
+        )
+
+    def retrieve(self, query: str) -> List[str]:
+        vector = self.embedder.encode(query).reshape(1, -1)
+        scores, ids = self.index.search(vector, settings.top_k)
+        return [self.docs[i] for i in ids[0]]
+
+    async def generate(self, prompt: str) -> str:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.llm, prompt)
+
+    async def answer(self, question: str) -> str:
+        docs = self.retrieve(question)
+        context = "\n---\n".join(docs)
+        prompt = f"Context:\n{context}\n\nQuestion: {question}\nAnswer:"
+        return await self.generate(prompt)
+
+
+_chat = None
+
+
+def get_chat() -> RAGChat:
+    global _chat
+    if _chat is None:
+        _chat = RAGChat()
+    return _chat
+
+
+async def answer(question: str) -> str:
+    return await get_chat().answer(question)
+

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,17 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src import rag_chat
+
+
+@pytest.mark.asyncio
+async def test_answer_returns_string():
+    with patch.object(rag_chat, "get_chat") as mock_chat:
+        mock_instance = AsyncMock()
+        mock_instance.answer.return_value = "ok"
+        mock_chat.return_value = mock_instance
+        result = await rag_chat.answer("test question")
+        assert isinstance(result, str)
+


### PR DESCRIPTION
## Summary
- create offline medical RAG assistant skeleton
- include config, embeddings, indexer, ingestion, rag chat, and GUI modules
- add placeholder data sources and README instructions
- provide minimal pytest for pipeline

## Testing
- `pytest`